### PR TITLE
Revert to PHP5.3 array declaration

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -325,11 +325,11 @@ class PluginCustomfieldsField extends CommonDBTM {
           Log::history(
               $this->fields["id"],
               $this->associatedItemType(),
-              [
+              array(
                   0,
                   $oldvalues,
                   $newvalues
-              ],
+              ),
               0,
               Log::HISTORY_UPDATE_SUBITEM
           );


### PR DESCRIPTION
Change the shorthand [] array declaration to array(), so we're in line with GLPI's PHP5.3 prerequisites.
